### PR TITLE
[FIX] NULL datetime issue on tOpenERPOutput

### DIFF
--- a/tOpenERPOutput/tOpenERPOutput_main.javajet
+++ b/tOpenERPOutput/tOpenERPOutput_main.javajet
@@ -62,7 +62,7 @@ if(version_selection.equals("OPENERP_70")) {
 	if (<%=incomingConnName%>.<%=column.getLabel()%>!=null && !"".equals(<%=incomingConnName%>.<%=column.getLabel()%>)) {
 		valueMap_<%=cid%>.put("<%=column.getLabel()%>",<%=incomingConnName%>.<%=column.getLabel()%>);
 	} else {
-		valueMap_<%=cid%>.put("<%=column.getLabel()%>","");
+		valueMap_<%=cid%>.put("<%=column.getLabel()%>",false);
 	}
 <%						
 				}


### PR DESCRIPTION
an error that occurs when you put a null date. In OpenERP null value is "False" and not an empty string.
