### PR TITLE
Update tOpenERPInput_begin.javajet

### DIFF
--- a/tOpenERPInput/tOpenERPInput_begin.javajet
+++ b/tOpenERPInput/tOpenERPInput_begin.javajet
@@ -183,7 +183,7 @@ if ((metadatas!=null)&&(metadatas.size()>0)) {  //1
 <%
 				    	} else if (javaType == JavaTypesManager.DATE) { 
 %>
-					<%=outgoingConn.getName()%>.<%=columnList.get(i).getLabel()%> = ParserUtils.parseTo_Date((String) value_<%=cid%>, <%= patternValue %>);
+					<%=outgoingConn.getName()%>.<%=columnList.get(i).getLabel()%> = (Date) value_<%=cid%>;
 <%					
 				    	} else if (javaType == JavaTypesManager.BYTE_ARRAY) { // byte[]
 %>


### PR DESCRIPTION
Date conversion is no longer needed with the last Talend Open Studio (TOS-r118616-v5.5.1).
